### PR TITLE
feature(OSPO): template update to include SBOM link in README.md content

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -27,7 +27,7 @@ We are grateful for the collaboration that has helped shape this repository.
 
 ## Individual contributions
 
-For a list of individual contributors who have made direct commits to this repository, see GitHub’s auto-generated contributor insights: [Contributors](https://github.com/National-Digital-Twin/archetypes/graphs/contributors).
+For a list of individual contributors who have made direct commits to this repository, see GitHub’s auto-generated contributor insights: [Contributors](../../graphs/contributors).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines  
 
-**Repository:** `[archetypes]`  
+**Repository:** `sbom-aggregation`  
 **Description:** `Guidelines for issue reporting, documentation suggestions, and NDTP’s controlled contribution model.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 
@@ -10,7 +10,7 @@ The National Digital Twin Programme (NDTP) develops and maintains this repositor
 
 NDTP follows an **open-source governance model** where all code is **publicly available** under open-source licences, and collaboration is invited from **approved partners**. Contributions from the general public are not currently accepted, but **feedback, issue reporting, and documentation suggestions are encouraged**.  
 
-If you want to see which suppliers and organisations have contributed to this repository in the past, refer to [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md) and the GitHub contributor insights page at [Contributors](https://github.com/National-Digital-Twin/archetypes/graphs/contributors).  
+If you want to see which suppliers and organisations have contributed to this repository in the past, refer to [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md) and the GitHub contributor insights page at [Contributors](../../graphs/contributors).
 
 ---
 
@@ -34,7 +34,7 @@ For details on repository maintainers and how to contact them, refer to [MAINTAI
 
 If you encounter a bug, error, or inconsistency, please follow these steps:  
 
-1. Check for an existing issue under [Issues](https://github.com/National-Digital-Twin/archetypes/issues).  
+1. Check for an existing issue under [Issues](../../issues).  
 2. Open a new issue if no one has reported it yet. Use one of the provided issue templates.  
 3. Provide a clear, detailed description of the issue, including steps to reproduce it if applicable.  
 4. Label the issue appropriately (bug, documentation, enhancement, etc.).  
@@ -61,7 +61,7 @@ We prioritise documentation updates based on user impact and alignment with prog
 - **Development is led by approved suppliers and partners** who have been engaged through a formal process.  
 - **We welcome feedback and ideas**, but implementation is subject to programme priorities.  
 
-To see what we’re working on, check out our [Project Roadmap](https://github.com/National-Digital-Twin/archetypes/projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.  
+To see what we’re working on, check out our [Project Roadmap](../../projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.  
 
 ---
 
@@ -92,7 +92,9 @@ To maintain high-quality contributions, NDTP enforces the following **minimum pu
 - **PRs should use "squash and merge" as the preferred merge strategy**, ensuring a clean history.  
 - **Feature and bugfix branches should be deleted after merge** to keep the repository tidy.  
 - **Force pushing to the `main` branch is strictly prohibited** to protect repository integrity.  
-- **CI builds must pass before merging** to enforce basic validation checks.
+- **CI builds must pass before merging** to enforce basic validation checks.  
+
+For further details, see [CONTRIBUTING.md](./CONTRIBUTING.md).   
 
 ---
 
@@ -115,8 +117,11 @@ NDTP repository maintainers review reported issues, evaluate documentation sugge
 
 ---
 
-**Maintained by the National Digital Twin Programme (NDTP).**   
+Maintained by the National Digital Twin Programme (NDTP).  
 
 © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.  
+
 Licensed under the Open Government Licence v3.0.  
+
 For full licensing terms, see [OGL_LICENCE.md](./OGL_LICENCE.md)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines  
 
-**Repository:** `sbom-aggregation`  
+**Repository:** `[archetypes]`   
 **Description:** `Guidelines for issue reporting, documentation suggestions, and NDTP’s controlled contribution model.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 
@@ -84,17 +84,15 @@ For more details, refer to [GitFlow Workflow](https://www.atlassian.com/git/tuto
 
 To maintain high-quality contributions, NDTP enforces the following **minimum pull request (PR) requirements** for approved contributors:  
 
-- **All PRs must be reviewed by at least one maintainer** before merging.  
-- **PRs should reference a corresponding issue** where applicable.  
-- **Code changes must include relevant tests** to ensure stability.  
-- **Commit messages should follow best practices**, including referencing issue numbers when relevant.  
-- **Documentation updates should accompany PRs that impact functionality.**  
-- **PRs should use "squash and merge" as the preferred merge strategy**, ensuring a clean history.  
-- **Feature and bugfix branches should be deleted after merge** to keep the repository tidy.  
-- **Force pushing to the `main` branch is strictly prohibited** to protect repository integrity.  
-- **CI builds must pass before merging** to enforce basic validation checks.  
-
-For further details, see [CONTRIBUTING.md](./CONTRIBUTING.md).   
+- **All PRs must be reviewed by at least one maintainer** before merging.
+- **PRs should reference a corresponding issue** where applicable.
+- **Code changes must include relevant tests** to ensure stability.
+- **Commit messages should follow best practices**, including referencing issue numbers when relevant.
+- **Documentation updates should accompany PRs that impact functionality.**
+- **PRs should use "squash and merge" as the preferred merge strategy**, ensuring a clean history.
+- **Feature and bugfix branches should be deleted after merge** to keep the repository tidy.
+- **Force pushing to the `main` branch is strictly prohibited** to protect repository integrity.
+- **CI builds must pass before merging** to enforce basic validation checks.
 
 ---
 
@@ -117,7 +115,7 @@ NDTP repository maintainers review reported issues, evaluate documentation sugge
 
 ---
 
-Maintained by the National Digital Twin Programme (NDTP).  
+**Maintained by the National Digital Twin Programme (NDTP).**
 
 © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme and is legally attributed to the Department for Business and Trade (UK) as the governing entity.  
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,14 @@ This repository contains both source code and documentation, which are covered b
 
 See [`LICENSE.md`](LICENSE.md), [`OGL_LICENCE.md`](OGL_LICENCE.md) and [`NOTICE.md`](NOTICE.md) for details.
 
-## Security and Responsible Disclosure  
+## Security and Responsible Disclosure
 We take security seriously. If you believe you have found a security vulnerability in this repository, please follow our responsible disclosure process outlined in [`SECURITY.md`](./SECURITY.md).  
+
+## Software Bill of Materials (SBOM)
+This project provides a Software Bill of Materials (SBOM) to help users and integrators understand its dependencies.
+
+### Current SBOM
+Download the [latest SBOM for this codebase](../../dependency-graph/sbom) to view the current list of components used in this repository.
 
 ## Contributing  
 We welcome contributions that align with the Programme’s objectives. Please read our [`CONTRIBUTING.md`](./CONTRIBUTING.md) guidelines before submitting pull requests.  


### PR DESCRIPTION
### Type of Change
New feature

### Description 
Update README.md template to include link to download SBOM on demand. Please note this PR also includes a move to relative links for repository level resources (e.g., contributors, dependency graphs etc.), which reduces the amount of template replacement/updates needed for consumers.